### PR TITLE
fix: deleteUpload & checkComplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hf-upload",
-  "version": "3.2.4-alpha.6",
+  "version": "3.2.4-alpha.8",
   "description": "An upload tool",
   "main": "./lib/index.js",
   "types": "./declaration/index.d.ts",

--- a/src/upload/upload-ali.ts
+++ b/src/upload/upload-ali.ts
@@ -4,6 +4,7 @@ import { UploadStatus } from '../enums'
 import { UploadFile, UploadOptions, AliProps, SingleFileFn, PromiseFn } from '../types'
 
 export default class AliUpload {
+  deleted: boolean
   params: any
   options: UploadOptions
   timeout: number
@@ -114,7 +115,7 @@ export default class AliUpload {
               setTimeout(async () => {
                 await this.needUpdateParams(this.file)
                 this.reUpload()
-              }, 1000)
+              }, 3000)
             } else {
               this.file.status = UploadStatus.Error
               this.file.errorMessage = 'params is expired'
@@ -156,7 +157,8 @@ export default class AliUpload {
   }
 
   startUpload = () => {
-    if (!this.file) return
+    if (this.deleted) return
+
     const applyTokenDo = (func: any) => {
       const client = new OSS({
         timeout: this.timeout,
@@ -170,8 +172,8 @@ export default class AliUpload {
   }
 
   deleteUpload = () => {
-    this.uploadFileClient = null
-    this.file = null
+    this.cancelUpload()
+    this.deleted = true
   }
 
   cancelUpload = () => {


### PR DESCRIPTION
fix：
- 参数过期时，删除上传文件后仍继续重传问题
- 删除文件之前分片上传请求已经发送，上传成功的回调会继续执行问题
