### PR TITLE
fix: md5计算失败

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hf-upload",
-  "version": "3.3.0",
+  "version": "3.3.1-alpha.2",
   "description": "An upload tool",
   "main": "./lib/index.js",
   "types": "./declaration/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hf-upload",
-  "version": "3.3.1-alpha.2",
+  "version": "3.3.1-alpha.4",
   "description": "An upload tool",
   "main": "./lib/index.js",
   "types": "./declaration/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,10 @@ import { updateFileLists, deleteFile, deleteId, preproccessFile, fileToObject } 
 import defaultOptions from './default'
 import { UploadStatus } from './enums'
 import { UploadFile, UploadOptions, UploadProps, MultiFileFn, PromiseFn, Noop } from './types'
-import createWorkerFn from './worker.js'
+import workerContent from './worker.js'
 
 export * from './types'
 
-const [, workerContent] = createWorkerFn.toString().split('/* separator */')
 let UPLOAD_BLOB
 
 export default class HFUploader {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,5 @@
 const workerContent = `
-importScripts('https://cdnout.com/spark-md5/')
+importScripts('https://static.hellorf.com/fe/hf-upload/spark-md5.js')
   onmessage = function (e) {
     function md5File(file) {
       const proto = Object.getPrototypeOf(file)

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,5 @@
-export default function createWorker() {
-  /* separator */
-  importScripts('https://cdnout.com/spark-md5/')
+const workerContent = `
+importScripts('https://cdnout.com/spark-md5/')
   onmessage = function (e) {
     function md5File(file) {
       const proto = Object.getPrototypeOf(file)
@@ -42,5 +41,6 @@ export default function createWorker() {
       md5File(e.data.file)
     }
   }
-  /* separator */
-}
+`
+
+export default workerContent


### PR DESCRIPTION
- fix：worker.js 导出方式
- fix：将spark-md5.js 放在静态资源中，实用static.hellorf.com引入，解决之前路径加载失败问题